### PR TITLE
added freifunk oberberg community, split from fichtenfunk

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -194,6 +194,7 @@
 	"niex" : "https://www.opennet-initiative.de/freifunk/api.freifunk.net-niex.json",
 	"niederkassel" : "https://raw.githubusercontent.com/Freifunk-Rhein-Sieg/api-json/master/niederkassel.json",
 	"nuernberg" : "https://raw.githubusercontent.com/FreifunkFranken/freifunkfranken-community/master/nuernberg.json",
+	"oberberg" : "http://api.freifunk-oberberg.de/oberberg.json",
 	"oberhausen" : "https://raw.githubusercontent.com/ffruhr/ffapi/master/oberhausen.json",
 	"obernkirchen" : "http://freifunk-obernkirchen.de/FreifunkObernkirchen-api.json",
 	"odenthal" : "http://api.gl.wupper.freifunk-rheinland.net/ode.json",


### PR DESCRIPTION
Added oberberg as we have to split form fichtenfunk. The given URL will be reachable after DNS updates are propagated.
